### PR TITLE
Fix: small mistake in doc file

### DIFF
--- a/cus-cn.tex
+++ b/cus-cn.tex
@@ -4625,7 +4625,7 @@ cbl 列表除了 \cs{cus@type@contentsline}、\cs{cus@type@contentsline@}、
       \topsep\z@ \partopsep\z@ \itemsep\z@ \parsep\z@ \parskip\z@}}
   {\item \begingroup\color{tocgreen}\bfseries}
   {\tocifnumbered{\tocthenumber\quad}{}\tocthename\breakablefiller[space]%
-    \makebox[1.1.5em][r]{\tochyperpage\;}\par }
+    \makebox[1.5em][r]{\tochyperpage\;}\par }
   {\endgroup}
   {\end{list}}
 \tocsetstyle {subsection,2}


### PR DESCRIPTION
https://github.com/Sophanatprime/cus/blob/c1b5b8b940c23fcb40c568cfce061126636737df/cus-cn.tex#L4657

An extra dot: `1.1.5em` $\to$ `1.5em`