### PR TITLE
Fix typos

### DIFF
--- a/buffer.sty
+++ b/buffer.sty
@@ -1342,7 +1342,7 @@
   }
 
 \msg_new:nnn { buffer } { char-enable-unknown } 
-  { The~char~`U+#1'~is~unregistered,~cannot~be~enbaled~or~disabled. }
+  { The~char~`U+#1'~is~unregistered,~cannot~be~enabled~or~disabled. }
 %endregion
 
 

--- a/cus-cn.tex
+++ b/cus-cn.tex
@@ -1702,7 +1702,7 @@ Unicode 代码点。
 \end{function}
 
 \begin{xample}
-我能吞下玻璃而不伤身体，I can eat glass, it dosen't hurt me.%
+我能吞下玻璃而不伤身体，I can eat glass, it doesn't hurt me.%
 \atleastfiller[cdotted=1em]{5cm}断行。
 
 我能吞下玻璃而不伤身体。\atleastfiller[cdotted=1em]{5cm}不断。
@@ -1733,10 +1733,10 @@ Unicode 代码点。
   \Replicate{#3-1}{\break \rule{0pt}{0.7\baselineskip}\filler[#1]}%
   #4\par}}
 
-我能吞下玻璃而不伤身体，I can eat glass, it dosen't hurt me.
+我能吞下玻璃而不伤身体，I can eat glass, it doesn't hurt me.
 \filllines{\linespread{2}\selectfont}{3}{。\hspace*{1em}}
 
-我能吞下玻璃而不伤身体，I can eat glass, it dosen't hurt me.
+我能吞下玻璃而不伤身体，I can eat glass, it doesn't hurt me.
 \filllines[color=red,dotted]{\linespread{2}\selectfont}{3}{。\hspace*{1em}}
 
 % 整行

--- a/example/eg-struct-cbl-p-t.tex
+++ b/example/eg-struct-cbl-p-t.tex
@@ -124,7 +124,7 @@
   \tmcbl@code{#1}{#2}{#3}{#4}{#5}{#6}{#7}%
 }
 \newcommand\mytmcbl@code@[7]{%
-  \ifnum\c@tocdepth>\inteval{#4-1}\relax
+  \ifnum\c@tocdepth>\interval{#4-1}\relax
     \expandafter\@firstofone\else\expandafter\@gobble\fi
   {\ifvmode \ifnum\tmcbl@beforepenalty=\z@\else\addpenalty{\tmcbl@beforepenalty}\fi
       \tmcbl@skipifnz\vskip\tmcbl@beforeskip 

--- a/example/eg-struct-cbl-p-t.tex
+++ b/example/eg-struct-cbl-p-t.tex
@@ -124,7 +124,7 @@
   \tmcbl@code{#1}{#2}{#3}{#4}{#5}{#6}{#7}%
 }
 \newcommand\mytmcbl@code@[7]{%
-  \ifnum\c@tocdepth>\interval{#4-1}\relax
+  \ifnum\c@tocdepth>\inteval{#4-1}\relax
     \expandafter\@firstofone\else\expandafter\@gobble\fi
   {\ifvmode \ifnum\tmcbl@beforepenalty=\z@\else\addpenalty{\tmcbl@beforepenalty}\fi
       \tmcbl@skipifnz\vskip\tmcbl@beforeskip 

--- a/library/cus.library.analysis.tex
+++ b/library/cus.library.analysis.tex
@@ -255,12 +255,12 @@
   }
 \cs_new:Npn \__cus_analysis_control_sequence_envcommand:Nnn #1#2#3
   {
-    \__cus_analysis_cstype_and_push:n { document~envrionment }
+    \__cus_analysis_cstype_and_push:n { document~environment }
     \__cus_analysis_command_interactive:N #1
   }
 \cs_new:Npn \__cus_analysis_control_sequence_envenvcommand:Nnn #1#2#3
   {
-    \__cus_analysis_cstype_and_push:n { document~end~envrionment }
+    \__cus_analysis_cstype_and_push:n { document~end~environment }
     \__cus_analysis_command_interactive:N #1
   }
 \cs_new:Npn \__cus_analysis_command_interactive:N #1
@@ -458,7 +458,7 @@ control sequence：
       LaTeX newcommand with option arg 
       LaTeX robust command
       LaTeX cmd command 
-      LaTeX cmd envrionment 
+      LaTeX cmd environment 
       pure tl 
     has parameter
     --- outer 

--- a/library/cus.library.doc.tex
+++ b/library/cus.library.doc.tex
@@ -85,7 +85,7 @@
 \cs_generate_variant:Nn \tl_to_str:n { f , o }
 
 
-% basicly is l3doc.cls and ctxdoc.cls 
+% basically is l3doc.cls and ctxdoc.cls 
 \cs_if_exist:NF \actualchar { \tl_set:Nn \actualchar {=} }
 \cs_if_exist:NF \quotechar { \tl_set:Nn \quotechar {!} }
 \cs_if_exist:NF \levelchar { \tl_set:Nn \levelchar {>} }

--- a/module/cus.module.algo.tex
+++ b/module/cus.module.algo.tex
@@ -1,4 +1,4 @@
-\CUSProvideExplModule{algo}{\cus@d@te}{\cus@versi@n}{algorithms writen in TeX}
+\CUSProvideExplModule{algo}{\cus@d@te}{\cus@versi@n}{algorithms written in TeX}
 
 \cs_new_protected:Npn \__cus_algo_init:N #1 { \cs_set_eq:NN #1 \c_empty_tl }
 \cs_new:Npn \__cus_algo_map:NN #1#2

--- a/module/cus.module.box.tex
+++ b/module/cus.module.box.tex
@@ -327,7 +327,7 @@
           % update frame measurement to use \__cus_box_frame_first:n or \__cus_box_frame_middle:n 
           \__cus_box_frame_measure:N #3
           \vbox_set:Nn #1
-            {% simulate frame and flexiblity of the page:
+            {% simulate frame and flexibility of the page:
               \tex_vskip:D \l__cus_box_ht_dim \@plus\tex_pagestretch:D \@minus0.8\tex_pageshrink:D 
               \tex_kern:D 137sp \tex_kern:D -137sp \tex_penalty:D -30 ~
               \vbox_unpack_drop:N #1

--- a/module/cus.module.package.tex
+++ b/module/cus.module.package.tex
@@ -92,9 +92,9 @@
   {
     \cs_set:Npn \< { \s_stop before               \s_stop }
     \cs_set:Npn \> { \s_stop after                \s_stop }
-    \cs_set:Npn \! { \s_stop imcompatible-warning \s_stop }
-    \cs_set:Npn \x { \s_stop imcompatible-error   \s_stop }
-    \cs_set:Npn \~ { \s_stop imcompatible-ignore  \s_stop }
+    \cs_set:Npn \! { \s_stop incompatible-warning \s_stop }
+    \cs_set:Npn \x { \s_stop incompatible-error   \s_stop }
+    \cs_set:Npn \~ { \s_stop incompatible-ignore  \s_stop }
     \cs_set:Npn \= { \s_stop voids                \s_stop }
     \cs_set:Npn \? { \s_stop unrelated            \s_stop }
     \cs_set:Npn \& { \s_stop require              \s_stop }
@@ -112,15 +112,15 @@
 \cs_new_eq:cN { __cus_package_rule_<_gset:nn } \__cus_package_rule_before_gset:nn
 \cs_new_protected:Npn \__cus_package_rule_after_gset:nn #1#2 { }
 \cs_new_eq:cN { __cus_package_rule_>_gset:nn } \__cus_package_rule_after_gset:nn
-\cs_new_protected:cpn { __cus_package_rule_ imcompatible-warning _gset:nn } #1#2 { }
+\cs_new_protected:cpn { __cus_package_rule_ incompatible-warning _gset:nn } #1#2 { }
 \cs_new_eq:cc { __cus_package_rule_!_gset:nn }
-  { __cus_package_rule_ imcompatible-warning _gset:nn } 
-\cs_new_protected:cpn { __cus_package_rule_ imcompatible-error _gset:nn } #1#2 { }
+  { __cus_package_rule_ incompatible-warning _gset:nn } 
+\cs_new_protected:cpn { __cus_package_rule_ incompatible-error _gset:nn } #1#2 { }
 \cs_new_eq:cc { __cus_package_rule_x_gset:nn }
-  { __cus_package_rule_ imcompatible-error _gset:nn } 
-\cs_new_protected:cpn { __cus_package_rule_ imcompatible-ignore _gset:nn } #1#2 { }
+  { __cus_package_rule_ incompatible-error _gset:nn } 
+\cs_new_protected:cpn { __cus_package_rule_ incompatible-ignore _gset:nn } #1#2 { }
 \cs_new_eq:cc { __cus_package_rule_ \c_tilde_str _gset:nn }
-  { __cus_package_rule_ imcompatible-ignore _gset:nn } 
+  { __cus_package_rule_ incompatible-ignore _gset:nn } 
 \cs_new_protected:Npn \__cus_package_rule_voids_gset:nn #1#2 { }
 \cs_new_eq:cN { __cus_package_rule_=_gset:nn } \__cus_package_rule_voids_gset:nn
 \cs_new_protected:Npn \__cus_package_rule_unrelated_gset:nn #1#2 { }
@@ -134,9 +134,9 @@
 
 
 \int_const:Nn \c__cus_package_rule_unrelated_int { 0 }
-\int_const:Nn \c__cus_package_rule_xW_int { 1 } % imcompatible-warning
-\int_const:Nn \c__cus_package_rule_xE_int { 2 } % imcompatible-error
-\int_const:Nn \c__cus_package_rule_xI_int { 3 } % imcompatible-ignore
+\int_const:Nn \c__cus_package_rule_xW_int { 1 } % incompatible-warning
+\int_const:Nn \c__cus_package_rule_xE_int { 2 } % incompatible-error
+\int_const:Nn \c__cus_package_rule_xI_int { 3 } % incompatible-ignore
 \int_const:Nn \c__cus_package_rule_voids_int { 4 }
 \int_const:Nn \c__cus_package_rule_require_int { 5 }
 \int_const:Nn \c__cus_package_rule_call_int { 6 }
@@ -186,9 +186,9 @@
 
 <  before                 1在2之前加载
 >  after                  1在2之后加载
-!  imcompatible-warning   1与2不兼容，警告，如果某一个加载了则后一个不加载，可以为空
-x  imcompatible-error     1与2不兼容，报错，如果某一个加载了则后一个不加载，可以为空
-~  imcompatible-ignore    1与2不兼容，忽略，如果某一个加载了则后一个不加载，可以为空
+!  incompatible-warning   1与2不兼容，警告，如果某一个加载了则后一个不加载，可以为空
+x  incompatible-error     1与2不兼容，报错，如果某一个加载了则后一个不加载，可以为空
+~  incompatible-ignore    1与2不兼容，忽略，如果某一个加载了则后一个不加载，可以为空
 =  voids / overwrite      如果要加载2，则替换为1
 ?  unrelated              不相关或未定义
 &  require                1加载时在它之前加载2

--- a/module/cus.module.struct.tex
+++ b/module/cus.module.struct.tex
@@ -2426,7 +2426,7 @@
     \else: \exp_after:wN \use_ii:nn
     \fi:
   }
-% see \str_case:nnTF, ect.
+% see \str_case:nnTF, etc.
 \cs_new:Npn \__cus_title_mode_case:nnTF #1#2#3#4
   {
     \exp:w \__cus_title_mode_case:nw {#1} #2 {#1} { }


### PR DESCRIPTION
Found via `codespell -S *.pdf,framedmulticol.sty -L te,ist,bu,ot,nd,acn,noo,lod,fo,openin,inteval` and `typos --hidden --format brief`